### PR TITLE
fix: old device crash on resume

### DIFF
--- a/ios/Classes/FlutterRadioPlugin.m
+++ b/ios/Classes/FlutterRadioPlugin.m
@@ -293,6 +293,9 @@ FlutterMethodChannel* _channel;
     
     if (audioPlayer.currentItem != nil){
         [audioPlayer pause];
+        [audioPlayer.currentItem removeObserver:self forKeyPath:@"status"];
+        [audioPlayer removeObserver:self forKeyPath:@"rate"];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemPlaybackStalledNotification object:nil];
     }
     
     for (id<AudioPlayerListener> listener in [_listeners allObjects]) {


### PR DESCRIPTION
На старых девайсах при повторном воспроизведении происходил крэш приложения